### PR TITLE
Allow installation via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "pourover",
+  "main": "pourover.js",
+  "version": "0.0.0",
+  "homepage": "http://nytimes.github.io/pourover/",
+  "authors": [
+    "NYTimes"
+  ],
+  "description": "A library for simple, fast filtering and sorting of large collections in the browser",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "filter",
+    "sort",
+    "colections"
+  ],
+  "license": "Apache-2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "underscore": "~1.6.0"
+  }
+}


### PR DESCRIPTION
A slightly-better-than-stub bower.json file. `authors` will need to be updated. The `pourover` entry in bower is currently pointing at my fork, but if this gets merged I'll unregister so you can publish using your repo.