### PR TITLE
Fixing advanced/custom-sort example

### DIFF
--- a/examples/advanced_views.js
+++ b/examples/advanced_views.js
@@ -31,15 +31,16 @@ var view = new PourOver.View("default_view", collection);
 
 // ### Sorting
 
-// To create a sort, we generally extend the Sort object with a `fn`, the comparator function used to order items.
+// #### Creating a custom sort
+// To create a custom sort, we generally extend the Sort object with a `fn`, the comparator function used to order items.
 // We also specify which attribute the sort operates over -- what it sorts with respect to --  with the `attr` attribute.
 // Then, we instantiate our new sort.
 var RevNameSort = PourOver.Sort.extend({
-    attr: "name",
     fn: function(a,b){
-        if (b < a){
+        var x = a.name, y = b.name;    
+        if (y < x){
           return -1;
-        } else if (b > a){
+        } else if (y > x){
           return 1;
         } else {
           return 0;


### PR DESCRIPTION
As far as I can tell, setting `attr` does not have an effect as to what is used for arguments `a` and `b`. 

i.e. setting `attr` to "name" will not set `a` to `collectionMember.name` for comparison purposes.

It's obviously easier to fix up the docs than to change the Sort internals...however, maybe it's better this way, to not make any use of an `attr` setting, because the common use-case for a custom Sort is to work with the member objects directly, for elaborate sorting procedures?

(It's possible that I just missed a huge step in the docs and source-code, but `a` and `b` were not affected by whatever I set `attr` to)
