### PR TITLE
Load fonts using https to prevent mixed-content warnings

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/public/css/poole.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/public/css/syntax.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/public/css/hyde.css">
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/public/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
This change fixes missing fonts when using the https version of GitHub pages (https://nytimes.github.io/pourover/).