### PR TITLE
Enables use as NPM require, relative path

### DIFF
--- a/pourover.js
+++ b/pourover.js
@@ -1928,3 +1928,7 @@ var PourOver = (function(){
 
     return PourOver;
 })();
+
+if (typeof module != 'undefined' && module.exports) {
+  module.exports = PourOver;
+}

--- a/pourover.js
+++ b/pourover.js
@@ -1,3 +1,7 @@
+if (typeof _ == 'undefined' && typeof require == 'function') {
+    var _ = require('underscore');
+}
+
 var PourOver = (function(){
     var ctor = function(){};
 


### PR DESCRIPTION
like `var PourOver = require('./pourover')` until a full npm module is made
