### PR TITLE
More efficient insert_sorted

### DIFF
--- a/dist/pourover.js
+++ b/dist/pourover.js
@@ -90,7 +90,8 @@ var PourOver = (function(){
         }
         while(i < length){
           if(element < set[i]){
-            return set.slice(0,i).concat([element]).concat(set.slice(i,length));
+            set.splice(i, 0, element);
+            return set;
           } else {
             i++;
           }


### PR DESCRIPTION
Splicing once is more efficient than 2 slices and 2 concats.

Ocurred on IE8 while going over large array. `slice`+`concat` version made browser display the "Script is running too slow" monit. `splice` version fixed it, boosting speed of script almost twice.
